### PR TITLE
docs: removed trailing whitespace on 11 line(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Comes in no particular order :recycle:
 
 <br>
 
-### :star: it and share with a friendly developer!  
+### :star: it and share with a friendly developer!
 
 <br>
 <br>
@@ -171,8 +171,8 @@ But knowing the stuff will help you become better! :muscle:*
 - :book: [Site Reliability Engineering](https://landing.google.com/sre/sre-book/toc/index.html)
 
 ### Career
-- :moneybag: [Levels FYI](https://www.levels.fyi)  
-  Salary stats for various tech companies. Better than Glassdoor. 
+- :moneybag: [Levels FYI](https://www.levels.fyi)
+  Salary stats for various tech companies. Better than Glassdoor.
 - :page_facing_up: [10 Things Every Programmer Should Know For Their First Job](http://www.applematters.com/article/10-things-every-programmer-should-know-for-their-first-job/)
 - :page_facing_up: [How Much Do Software Engineers Really Make in Each City?](https://www.codementor.io/blog/best-cities-software-engineer-earnings-271vpf599k)
 - :page_facing_up: [Software Engineers Tenure in San Francisco](https://hackerlife.co/blog/san-francisco-large-corporation-employee-tenure)
@@ -200,7 +200,7 @@ But knowing the stuff will help you become better! :muscle:*
 - :book: [97 things every programmer should know](https://github.com/97-things/97-things-every-programmer-should-know)
 - :movie_camera: [A Philosophy of Software Design | John Ousterhout | Talks at Google](https://wwwtube.com/watch?v=bmSAYlu0NcY&t=403s)
 
-###  Fine-tune Your Resume 
+###  Fine-tune Your Resume
 - :hammer: [CV Compiler](https://cvcompiler.com/)
 
 ### Open Source
@@ -223,7 +223,7 @@ But knowing the stuff will help you become better! :muscle:*
 - :book: [How to Win Friends and Influence People](https://www.goodreads.com/book/show/4865.How_to_Win_Friends_and_Influence_People)
 
 ### Mental Health
-- [Awesome Mental Health](https://github.com/dreamingechoes/awesome-mental-health)  
+- [Awesome Mental Health](https://github.com/dreamingechoes/awesome-mental-health)
   A curated list of awesome articles, websites and resources about mental health in the software industry.
 
 ### Papers on Programming
@@ -300,20 +300,20 @@ But knowing the stuff will help you become better! :muscle:*
 > A modern discipline that evolved from DevOps and SRE principles, focused on improving developer experience and productivity by building and managing self-service tools and workflows, often through an Internal Developer Platform (IDP). The goal is to reduce cognitive load on developers and streamline the path to production.
 
 - **What is Platform Engineering?**
-    * [Microsoft Learn: What is platform engineering?](https://learn.microsoft.com/en-us/platform-engineering/what-is-platform-engineering)  
+    * [Microsoft Learn: What is platform engineering?](https://learn.microsoft.com/en-us/platform-engineering/what-is-platform-engineering)
     A comprehensive overview of the practice, its goals, and core capabilities.
-    * [Atlassian: What is Platform Engineering?](https://www.atlassian.com/developer-experience/platform-engineering)  
+    * [Atlassian: What is Platform Engineering?](https://www.atlassian.com/developer-experience/platform-engineering)
     A great explanation of the roles and responsibilities of a platform team.
 
 - **Internal Developer Platform (IDP)**
-    * [internaldeveloperplatform.org: What is an IDP?](https://internaldeveloperplatform.org/what-is-an-internal-developer-platform/)  
+    * [internaldeveloperplatform.org: What is an IDP?](https://internaldeveloperplatform.org/what-is-an-internal-developer-platform/)
     A foundational resource explaining the concept of an IDP as the core product of a platform team.
-    * [Atlassian: Internal Developer Platform Guide](https://www.atlassian.com/developer-experience/internal-developer-platform)  
+    * [Atlassian: Internal Developer Platform Guide](https://www.atlassian.com/developer-experience/internal-developer-platform)
     A deep dive into the benefits and best practices for building an IDP.
 
 - **Golden Paths (Paved Roads)**
-    * [Spotify Engineering: How we use Golden Paths to solve fragmentation](https://backstage.spotify.com/learn/onboarding-software-to-backstage/setting-up-software-templates/11-spotify-templates/)  
+    * [Spotify Engineering: How we use Golden Paths to solve fragmentation](https://backstage.spotify.com/learn/onboarding-software-to-backstage/setting-up-software-templates/11-spotify-templates/)
     The original concept from Spotify, explaining how they use "opinionated and supported paths" to guide developers.
-    * [Red Hat: What is a Golden Path for software development?](https://www.redhat.com/en/topics/devops/golden-paths)  
+    * [Red Hat: What is a Golden Path for software development?](https://www.redhat.com/en/topics/devops/golden-paths)
     * A clear article on how Golden Paths provide templates and standardized workflows to increase efficiency.
 


### PR DESCRIPTION
## Description
removed trailing whitespace on 11 line(s)

This change improves documentation quality without altering any content meaning or functionality.

## Type of change
- [x] Documentation improvement

## Checklist
- [x] I have read the CONTRIBUTING guide
- [x] My changes follow the existing style and formatting
- [x] I have verified the changes render correctly